### PR TITLE
Change path of __main__.py when running from local installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Follower Count History is a Python module that collects Twitter follower count f
 $ git clone https://github.com/oduwsdl/FollowerCountHistory.git
 $ cd FollowerCountHistory
 $ pip install -r requirements.txt
-$  ./__main__.py [-h] [--st] [--et] [--freq] [--out] <Twitter handle/ Twitter URL>
+$  ./fch/__main__.py [-h] [--st] [--et] [--freq] [--out] <Twitter handle/ Twitter URL>
 ```
 #### Install from pypi
 ```shell


### PR DESCRIPTION
Running this from the root of the repo requires invoking `__main__.py` from a subdirectory rather than the root directory, where there is no `__main__.py`. This PR updates the README.md to resolve the invocation to the file in the subdirectory.