### PR TITLE
Fix docs for plot generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,6 @@ File Name| Description
   
  * Usage: GenerateD3Stub functions by passing n number of csv filepaths as parameters. The file generated afterwards 'generatedGraphStub.html' will have the embeddable code for use.
   ```shell
-  $  python GenerateD3Stub.py csv1path csv2path ... csvnpath
+  $  cd html_generator; python generateD3stub.py csv1path csv2path ... csvnpath
   ```
  * By default, the GenerateD3Stub will print the data passed to it in the console, so the user can verify the correct data is being passed.


### PR DESCRIPTION
I was not sure how to generate an interactive plot based on the README. I found the appropriate script within a subdirectory of the source and not the root. Further, the filename in the README was incorrectly cased, which would cause it to be failed to be executed on some systems.

This PR addresses the above issues by making tweaks to the README.

![mb](https://user-images.githubusercontent.com/2514780/185469544-2e019b96-3201-4737-9d75-570c13ab7c70.png)
